### PR TITLE
add vector3 to wrapper methods fixes #56

### DIFF
--- a/src/DeepCAdd.cpp
+++ b/src/DeepCAdd.cpp
@@ -21,7 +21,8 @@ class DeepCAdd : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -41,7 +42,8 @@ void DeepCAdd::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCClamp.cpp
+++ b/src/DeepCClamp.cpp
@@ -38,7 +38,8 @@ class DeepCClamp : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -58,7 +59,8 @@ void DeepCClamp::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCColorLookup.cpp
+++ b/src/DeepCColorLookup.cpp
@@ -29,7 +29,8 @@ class DeepCColorLookup : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -55,7 +56,8 @@ void DeepCColorLookup::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCGamma.cpp
+++ b/src/DeepCGamma.cpp
@@ -21,7 +21,8 @@ class DeepCGamma : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -41,7 +42,8 @@ void DeepCGamma::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCGrade.cpp
+++ b/src/DeepCGrade.cpp
@@ -50,7 +50,8 @@ class DeepCGrade : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -98,7 +99,8 @@ void DeepCGrade::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCID.cpp
+++ b/src/DeepCID.cpp
@@ -29,7 +29,8 @@ class DeepCID : public DeepCMWrapper
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3& sampleColor
             );
 
         virtual void _validate(bool for_real);
@@ -54,7 +55,8 @@ void DeepCID::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3& sampleColor
     )
 {
     // generate mask

--- a/src/DeepCInvert.cpp
+++ b/src/DeepCInvert.cpp
@@ -18,7 +18,8 @@ class DeepCInvert : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -33,7 +34,8 @@ void DeepCInvert::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCMWrapper.cpp
+++ b/src/DeepCMWrapper.cpp
@@ -30,7 +30,8 @@ void DeepCMWrapper::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3& sampleColor
     )
 {
     perSampleData = 1.0f;
@@ -45,7 +46,8 @@ void DeepCMWrapper::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     switch (_operation)

--- a/src/DeepCMWrapper.h
+++ b/src/DeepCMWrapper.h
@@ -49,13 +49,15 @@ class DeepCMWrapper : public DeepCWrapper
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3& sampleColor
             );
         virtual void wrappedPerChannel(
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void top_knobs(Knob_Callback f);

--- a/src/DeepCMultiply.cpp
+++ b/src/DeepCMultiply.cpp
@@ -21,7 +21,8 @@ class DeepCMultiply : public DeepCWrapper
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -41,7 +42,8 @@ void DeepCMultiply::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex = colourIndex(z);

--- a/src/DeepCPMatte.cpp
+++ b/src/DeepCPMatte.cpp
@@ -35,7 +35,8 @@ class DeepCPMatte : public DeepCMWrapper
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -57,7 +58,8 @@ void DeepCPMatte::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3& sampleColor
     )
 {
     // generate mask

--- a/src/DeepCPNoise.cpp
+++ b/src/DeepCPNoise.cpp
@@ -158,13 +158,15 @@ class DeepCPNoise : public DeepCMWrapper
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3& sampleColor
             );
         virtual void wrappedPerChannel(
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
         virtual void custom_knobs(Knob_Callback f);
 
@@ -233,7 +235,8 @@ void DeepCPNoise::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3& sampleColor
     )
 {
 
@@ -285,7 +288,8 @@ void DeepCPNoise::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     int cIndex;

--- a/src/DeepCSaturation.cpp
+++ b/src/DeepCSaturation.cpp
@@ -38,13 +38,15 @@ class DeepCSaturation : public DeepCWrapper
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3& sampleColor
             );
         virtual void wrappedPerChannel(
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3& sampleColor
             );
 
         virtual void custom_knobs(Knob_Callback f);
@@ -90,7 +92,8 @@ void DeepCSaturation::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3& sampleColor
     )
 {
     ChannelSet available;
@@ -135,7 +138,8 @@ void DeepCSaturation::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3& sampleColor
     )
 {
     outData = inputVal * _saturation + perSampleData * (1.0f - _saturation);

--- a/src/DeepCWrapper.cpp
+++ b/src/DeepCWrapper.cpp
@@ -83,7 +83,8 @@ void DeepCWrapper::wrappedPerSample(
     size_t sampleNo,
     float alpha,
     DeepPixel deepInPixel,
-    float &perSampleData
+    float &perSampleData,
+    Vector3 &sampleColor
     )
 {
     perSampleData = 1.0f;
@@ -98,7 +99,8 @@ void DeepCWrapper::wrappedPerChannel(
     const float inputVal,
     float perSampleData,
     Channel z,
-    float& outData
+    float& outData,
+    Vector3 &sampleColor
     )
 {
     outData = inputVal * _gain;
@@ -216,7 +218,8 @@ bool DeepCWrapper::doDeepEngine(
             }
 
             float perSampleData;
-            wrappedPerSample(it, sampleNo, alpha, deepInPixel, perSampleData);
+            Vector3 sampleColor;
+            wrappedPerSample(it, sampleNo, alpha, deepInPixel, perSampleData, sampleColor);
 
             // process the sample
             float inputVal;
@@ -256,7 +259,7 @@ bool DeepCWrapper::doDeepEngine(
                 if (_unpremult)
                     inputVal /= alpha;
 
-                wrappedPerChannel(inputVal, perSampleData, z, outData);
+                wrappedPerChannel(inputVal, perSampleData, z, outData, sampleColor);
 
                 float mask = _mix;
                 mask *= sideMaskVal;
@@ -302,12 +305,19 @@ void DeepCWrapper::bottom_knobs(Knob_Callback f)
     Divider(f, "");
 
     Input_Channel_knob(f, &_deepMaskChannel, 1, 0, "deep_mask", "deep input mask");
+    Tooltip(f, "Use an existing channel in your deep stream based on each sample.");
     Bool_knob(f, &_invertDeepMask, "invert_deep_mask", "invert");
+    Tooltip(f, "Invert the use of the deep mask channel.");
     Bool_knob(f, &_unpremultDeepMask, "unpremult_deep_mask", "unpremult");
+    Tooltip(f, "Unpremult the deep mask prior to applying it.");
 
-    Input_Channel_knob(f, &_sideMaskChannel, 1, 1, "side_mask");
+    Input_Channel_knob(f, &_sideMaskChannel, 1, 1, "side_mask", "side mask");
+    Tooltip(f, "Use a 2d mask connected as 2d nodes on the right.");
     Bool_knob(f, &_invertSideMask, "invert_mask", "invert");
+    Tooltip(f, "Invert the use of the side mask channel.");
     Float_knob(f, &_mix, "mix");
+    Tooltip(f, "Dissolve between the original Image at 0 and the fulll effect at 1.");
+
 }
 
 

--- a/src/DeepCWrapper.h
+++ b/src/DeepCWrapper.h
@@ -70,13 +70,15 @@ class DeepCWrapper : public DeepFilterOp
             size_t sampleNo,
             float alpha,
             DeepPixel deepInPixel,
-            float &perSampleData
+            float &perSampleData,
+            Vector3 &sampleColor
             );
         virtual void wrappedPerChannel(
             const float inputVal,
             float perSampleData,
             Channel z,
-            float& outData
+            float& outData,
+            Vector3 &sampleColor
             );
 
         bool doDeepEngine(


### PR DESCRIPTION
Inject a vector3 into both wrapper methods to avoid multiple calls for brothers when need all channels from a channelset 