### PR TITLE
Add nuke 14 and docker-based development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Then, from the DeepC dir:
 ```bash
 mkdir build; cd build
 cmake -D CMAKE_INSTALL_PREFIX="`pwd`/../install" ..
-make -j X install
+make -j $(nproc --all) install
 ```
 
-Where ```X``` is the number of cores you have available, so make can run parallelized. And, of course, update CMAKE_INSTALL_PREFIX to your preferred install location.
+And, of course, update CMAKE_INSTALL_PREFIX to your preferred install location.
 
 
 Note: additionally you can adjust the Nuke Version via -D Nuke_ROOT="<PATH_TO_NUKE_ROOT_FOLDER>"
@@ -127,6 +127,23 @@ e.g.
 ```
 cmake -D CMAKE_INSTALL_PREFIX="`pwd`/../install" -D Nuke_ROOT="/usr/local/Nuke13.1v1"
 ```
+
+### Linux (Docker)
+
+#### Nuke 14
+
+```bash
+docker run -v /usr/local/Nuke14.1v1:/usr/local/Nuke14.1v1 -v $PWD:/opt/aswf -it --rm aswf/ci-base:2022.4 /bin/bash
+```
+
+#### Nuke 13
+
+```bash
+docker run -v /usr/local/Nuke13.2v9:/usr/local/Nuke13.2v9 -v $PWD:/opt/aswf -it --rm aswf/ci-base:2020.9 /bin/bash
+```
+
+
+Then follow [Linux](#linux) instructions to build and install.
 
 ### Windows
 

--- a/cmake/FindNuke.cmake
+++ b/cmake/FindNuke.cmake
@@ -22,7 +22,7 @@
 #  NUKE_VERSION_RELEASE
 #
 
-set(_nuke_KNOWN_VERSIONS 9.0 10.0 10.5 11.0 11.1 11.2 11.3 12.0 12.1 12.2 13.0 13.1)
+set(_nuke_KNOWN_VERSIONS 9.0 10.0 10.5 11.0 11.1 11.2 11.3 12.0 12.1 12.2 13.0 13.1 13.2 14.0 14.1)
 set(_nuke_TEST_VERSIONS) # List of Nuke-style strings (e.g. "7.0v4")
 
 
@@ -61,12 +61,12 @@ else()
                 foreach(_known_version ${_nuke_KNOWN_VERSIONS})
                     # To avoid the need to keep this module up to date with the full Nuke
                     # release list, we just build a list of possible releases for the
-                    # MAJOR.MINOR pair (currently using possible release versions v1-v13)
+                    # MAJOR.MINOR pair (currently using possible release versions v1-v14)
                     # We don't try and auto-locate beta versions.
                     string(REGEX MATCH ${_nuke_VERSION_PATTERN} _nuke_VERSION_PREFIX ${_known_version})
                     if(_nuke_VERSION_PREFIX)
                         if(NOT ${_known_version} VERSION_LESS ${_nuke_FIND_MAJORMINOR})
-                            foreach(_release_num RANGE 13 1 -1)
+                            foreach(_release_num RANGE 14 1 -1)
                                 list(APPEND _nuke_TEST_VERSIONS "${_known_version}v${_release_num}")
                             endforeach()
                         endif()
@@ -87,7 +87,7 @@ else()
         # we can find, so flip the known versions list.
         list(REVERSE _nuke_KNOWN_VERSIONS)
         foreach(_known_version ${_nuke_KNOWN_VERSIONS})
-            foreach(_release_num RANGE 13 1 -1)
+            foreach(_release_num RANGE 14 1 -1)
                 list(APPEND _nuke_TEST_VERSIONS "${_known_version}v${_release_num}")
             endforeach()
         endforeach()


### PR DESCRIPTION
In this pull request:

- Added support for Nuke 14
- Updated README.md with how to compile using Docker, which should help to avoid installing the exact compiler toolchain on host OS.